### PR TITLE
Removes helm3 reference

### DIFF
--- a/scripts/helm3-uninstall.sh
+++ b/scripts/helm3-uninstall.sh
@@ -7,7 +7,8 @@ if [[ -n "${KUBECONFIG_IKS}" ]]; then
     export KUBECONFIG="${KUBECONFIG_IKS}"
 fi
 
-helm3 uninstall "${RELEASE_NAME}" --namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null
+SECRET_NAME=$(kubectl get secret --namespace "${NAMESPACE}" -o=custom-columns=name:.metadata.name | grep -E "sh.helm.release.*ibmcloud-config")
+kubectl delete "secret/${SECRET_NAME}" --namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null
 kubectl delete configmap/ibmcloud-config -namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null
 kubectl delete secret/ibmcloud-apikey --namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null
 


### PR DESCRIPTION
- Cleans up old helm chart install by deleting the secret holding the helm state (sh.helm.release.v1.ibmcloud-config.v1) and the configmap and secret

ibm-garage-cloud/planning#349