### PR TITLE
Updates min IBM Cloud terraform provider version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "ibm" {
-  version = ">= 1.2.1"
+  version = ">= 1.6.0"
 }
 provider "helm" {
   version = ">= 1.1.1"


### PR DESCRIPTION
- Sets the minimum IBM Cloud provider version to 1.6.0 to pick up required changes for VPC clusters

ibm-garage-cloud/planning#394