### PR TITLE
Updates the ibm provider version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "ibm" {
-  version = ">= 1.5.3"
+  version = ">= 1.7.1"
 }
 provider "helm" {
   version = ">= 1.1.1"


### PR DESCRIPTION
- Sets the minimum ibm terraform provider version to v1.7.1 to support VPC on OCP 4.3

ibm-garage-cloud/planning#403