### PR TITLE
Changes default OpenShift version to 4.6

### DIFF
--- a/main-0-setup.tf
+++ b/main-0-setup.tf
@@ -73,7 +73,7 @@ locals {
   substr(version, 0, 3) => "${version}_openshift"
   }
   cluster_regex         = "(${join("|", keys(local.config_values))}|ocp4).*"
-  cluster_type_cleaned  = regex(local.cluster_regex, var.cluster_type)[0] == "ocp4" ? "ocp43" : regex(local.cluster_regex, var.cluster_type)[0]
+  cluster_type_cleaned  = regex(local.cluster_regex, var.cluster_type)[0] == "ocp4" ? "ocp46" : regex(local.cluster_regex, var.cluster_type)[0]
   cluster_type          = local.config_values[local.cluster_type_cleaned].type
   # value should be ocp4, ocp3, or kubernetes
   cluster_type_code     = local.config_values[local.cluster_type_cleaned].type_code


### PR DESCRIPTION
Fixes bug introduced by the removal of the 4.3 version from the IBM Cloud catalog 

ibm-garage-cloud/planning#781

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>